### PR TITLE
Update ai to check for game end condition on Resume

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -68,10 +68,10 @@ export default {
         this.foundSet = false;
 
         //have ai check each time it resumes if game should end; copied from board logic
-        if (isDev)  console.log(`ai sets found: ${this.findValidSets().length}`);
-        if (isDev)  console.log(`ai cards left: ${deck.stock.length}`);
-        if (this.findValidSets().length === 0 && deck.stock.length === 0) {
-            setTimeout(() => game.end(), game.delay['add-cards']);
+        let numValidSets = this.findValidSets().length
+        if (isDev)  console.log(`ai sets found: ${numValidSets}, cards left: ${deck.stock.length`);
+        if (numValidSets === 0 && deck.stock.length === 0) {
+            game.end();
             return;
         }
 

--- a/js/ai.js
+++ b/js/ai.js
@@ -67,7 +67,7 @@ export default {
         this.test = 0;
         this.foundSet = false;
 
-        //have ai check each time it resumes if game should end; copied from board logic
+        // have ai check each time it resumes if game should end; this logic used to be in board.js before card draw
         let numValidSets = this.findValidSets().length
         if (isDev)  console.log(`ai sets found: ${numValidSets}, cards left: ${deck.stock.length`);
         if (numValidSets === 0 && deck.stock.length === 0) {

--- a/js/ai.js
+++ b/js/ai.js
@@ -67,6 +67,14 @@ export default {
         this.test = 0;
         this.foundSet = false;
 
+        //have ai check each time it resumes if game should end; copied from board logic
+        if (isDev)  console.log(`ai sets found: ${this.findValidSets().length}`);
+        if (isDev)  console.log(`ai cards left: ${deck.stock.length}`);
+        if (this.findValidSets().length === 0 && deck.stock.length === 0) {
+            setTimeout(() => game.end(), game.delay['add-cards']);
+            return;
+        }
+
         // Launch bot
         setTimeout(() => {
             if (!game.waiting) this.solve();

--- a/js/board.js
+++ b/js/board.js
@@ -34,11 +34,6 @@ export default {
             // Increment points
             game.updatePoints(1, winner);
 
-            if (ai.findValidSets().length === 0 && deck.stock.length === 0) {
-                setTimeout(() => game.end(), game.delay['add-cards']);
-                return;
-            }
-
             setTimeout(() => {
                 $('main').removeClass('waiting');
 


### PR DESCRIPTION
Since board.js used to check for game end condition (no sets, no cards left in deck) before it drew 3 cards, if the final draw left the board with no sets, the game would never go to end.  Moving it to the ai Resume function makes it check after cards are drawn instead, which should catch all instance instead of missing that 3% edge case, since the ai resumes at the start of each play.

I tried at first to add it to the board.js file right after draw 3 but that didn't work, I think because of the time delay on the drawing.  Having it check whenever the ai resumes ensures it would check again each turn to see if it needed to end if there were no valid sets and 0 cards in deck.  

I tested by speeding up the ai and animations and playing until I hit that state and confirming it ended the game, whereas before it would just sit there forever since it hadn't ended the game and had no more cards to add.  You can tell it succeeded here because the bot has 23 sets: 81 cards - 12 on the table without any sets = 69 cards = 23 sets.

<img width="960" alt="image" src="https://github.com/bofstein/set-game/assets/23406931/106728ac-82ec-4035-b6c6-2db967e308db">
